### PR TITLE
Feature/no std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Caching
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/rume/Cargo.toml
+++ b/rume/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/nicochatzi/rume"
 keywords = ["dsp", "audio", "graph", "no_std", "no-std"]
 categories = ["algorithms", "data-structures", "multimedia"]
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 rume_core = { path = "../rume_core" }
 rume_macros = { path = "../rume_macros" }

--- a/rume/Cargo.toml
+++ b/rume/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 readme = "README.md"
 homepage = "https://github.com/nicochatzi/rume"
 repository = "https://github.com/nicochatzi/rume"
-keywords = ["dsp", "audio", "graph", "no_std", "no-std"]
+keywords = ["dsp", "audio", "graph", "no_std"]
 categories = ["algorithms", "data-structures", "multimedia"]
 
 [features]

--- a/rume/Cargo.toml
+++ b/rume/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 readme = "README.md"
 homepage = "https://github.com/nicochatzi/rume"
 repository = "https://github.com/nicochatzi/rume"
-keywords = ["dsp", "audio", "graph"]
+keywords = ["dsp", "audio", "graph", "no_std", "no-std"]
 categories = ["algorithms", "data-structures", "multimedia"]
 
 [dependencies]

--- a/rume/src/lib.rs
+++ b/rume/src/lib.rs
@@ -1,5 +1,9 @@
+#![no_std]
+
 pub use rume_core::*;
 pub use rume_macros::*;
 
+#[cfg(target_os = "macos")]
 pub mod processors;
+#[cfg(target_os = "macos")]
 pub use processors::*;

--- a/rume/src/lib.rs
+++ b/rume/src/lib.rs
@@ -1,9 +1,9 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub use rume_core::*;
 pub use rume_macros::*;
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "std")]
 pub mod processors;
-#[cfg(target_os = "macos")]
+#[cfg(feature = "std")]
 pub use processors::*;

--- a/rume/src/lib.rs
+++ b/rume/src/lib.rs
@@ -5,5 +5,12 @@ pub use rume_macros::*;
 
 #[cfg(feature = "std")]
 pub mod processors;
+
 #[cfg(feature = "std")]
 pub use processors::*;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+pub use alloc::boxed::Box;

--- a/rume_core/Cargo.toml
+++ b/rume_core/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 readme = "README.md"
 homepage = "https://github.com/nicochatzi/rume"
 repository = "https://github.com/nicochatzi/rume"
-keywords = ["dsp", "audio", "graph", "no_std", "no-std"]
+keywords = ["dsp", "audio", "graph", "no_std"]
 categories = [""]
 
 [dependencies]

--- a/rume_core/Cargo.toml
+++ b/rume_core/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 readme = "README.md"
 homepage = "https://github.com/nicochatzi/rume"
 repository = "https://github.com/nicochatzi/rume"
-keywords = ["dsp", "audio", "graph"]
+keywords = ["dsp", "audio", "graph", "no_std", "no-std"]
 categories = [""]
 
 [dependencies]

--- a/rume_core/src/chain.rs
+++ b/rume_core/src/chain.rs
@@ -1,4 +1,5 @@
 use crate::{io::*, proc::*, sort::*};
+use alloc::vec::Vec;
 
 pub trait Renderable {
     fn render(&mut self, num_samples: usize);

--- a/rume_core/src/chain.rs
+++ b/rume_core/src/chain.rs
@@ -118,6 +118,7 @@ macro_rules! chain {
 mod test {
     use super::*;
     use crate::proc::dummies::*;
+    use alloc::vec;
 
     #[test]
     fn empty_chain_does_not_panic() {

--- a/rume_core/src/chain.rs
+++ b/rume_core/src/chain.rs
@@ -106,9 +106,9 @@ macro_rules! connect {
 #[macro_export]
 macro_rules! chain {
     ( $( ($out_proc:expr $(, $out_port_num:tt)*) => ($in_proc:expr $(, $in_port_num:tt)*)),* ) => {{
-        let mut builder = SignalChainBuilder::default();
+        let mut builder = $crate::SignalChainBuilder::default();
         $(
-            connect!(builder, ($out_proc $(, $out_port_num)*) => ($in_proc $(, $in_port_num)*));
+            $crate::connect!(builder, ($out_proc $(, $out_port_num)*) => ($in_proc $(, $in_port_num)*));
         )*
         builder.build()
     }};

--- a/rume_core/src/endpoints.rs
+++ b/rume_core/src/endpoints.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use core::ops::Range;
+use core::{ops::Range, option::Option};
 pub use heapless;
 pub use heapless::{
     consts::*,

--- a/rume_core/src/io.rs
+++ b/rume_core/src/io.rs
@@ -1,5 +1,5 @@
 use crate::proc::*;
-use alloc::rc::Rc;
+use alloc::{boxed::Box, rc::Rc};
 
 pub type DynInputPort = InputPort<dyn Processor, dyn Input<dyn Processor>>;
 pub type DynOutputPort = OutputPort<dyn Processor, dyn Output<dyn Processor>>;
@@ -212,7 +212,7 @@ macro_rules! make_output_port {
     ($proc:expr $(, $port_num:tt)*) => {
         $crate::OutputPort {
             proc: $proc.clone(),
-            port: Box::new($proc.clone().borrow().output $(. $port_num)* .clone()),
+            port: alloc::boxed::Box::new($proc.clone().borrow().output $(. $port_num)* .clone()),
         }
     };
 }
@@ -227,7 +227,7 @@ macro_rules! make_input_port {
     ($proc:expr $(, $port_num:tt)*) => {
         $crate::InputPort {
             proc: $proc.clone(),
-            port: Box::new($proc.clone().borrow().input $(. $port_num)* .clone()),
+            port: alloc::boxed::Box::new($proc.clone().borrow().input $(. $port_num)* .clone()),
         }
     };
 }

--- a/rume_core/src/io.rs
+++ b/rume_core/src/io.rs
@@ -1,5 +1,5 @@
 use crate::proc::*;
-use std::rc::Rc;
+use alloc::rc::Rc;
 
 pub type DynInputPort = InputPort<dyn Processor, dyn Input<dyn Processor>>;
 pub type DynOutputPort = OutputPort<dyn Processor, dyn Output<dyn Processor>>;

--- a/rume_core/src/lib.rs
+++ b/rume_core/src/lib.rs
@@ -1,6 +1,8 @@
 //!
 //!
 //!
+extern crate alloc;
+
 mod sort;
 
 #[macro_use]

--- a/rume_core/src/lib.rs
+++ b/rume_core/src/lib.rs
@@ -1,6 +1,8 @@
 //!
 //!
 //!
+#![no_std]
+
 extern crate alloc;
 
 mod sort;

--- a/rume_core/src/proc.rs
+++ b/rume_core/src/proc.rs
@@ -6,6 +6,7 @@ use alloc::{
 use core::{
     cell::RefCell,
     ops::{Deref, DerefMut},
+    option::Option,
 };
 
 #[derive(Clone, Copy)]

--- a/rume_core/src/proc.rs
+++ b/rume_core/src/proc.rs
@@ -1,9 +1,12 @@
 use crate::io::*;
+use alloc::{
+    rc::{Rc, Weak},
+    vec::Vec,
+};
 use core::{
     cell::RefCell,
     ops::{Deref, DerefMut},
 };
-use std::rc::{Rc, Weak};
 
 #[derive(Clone, Copy)]
 pub struct AudioConfig {

--- a/rume_core/src/sort.rs
+++ b/rume_core/src/sort.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 pub trait Sortable {
     fn next_nodes(&self, index: usize) -> Vec<usize>;
     fn num_nodes(&self) -> usize;
@@ -54,8 +56,8 @@ impl<'a> TopologicalSort<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::rc::{Rc, Weak};
     use core::cell::RefCell;
-    use std::rc::{Rc, Weak};
 
     #[derive(Default, Debug, Clone)]
     struct Node {

--- a/rume_core/src/sort.rs
+++ b/rume_core/src/sort.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 
 pub trait Sortable {
     fn next_nodes(&self, index: usize) -> Vec<usize>;

--- a/rume_macros/Cargo.toml
+++ b/rume_macros/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 readme = "README.md"
 homepage = "https://github.com/nicochatzi/rume"
 repository = "https://github.com/nicochatzi/rume"
-keywords = ["dsp", "audio", "graph", "no_std", "no-std"]
+keywords = ["dsp", "audio", "graph", "no_std"]
 categories = [""]
 
 [lib]

--- a/rume_macros/Cargo.toml
+++ b/rume_macros/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 readme = "README.md"
 homepage = "https://github.com/nicochatzi/rume"
 repository = "https://github.com/nicochatzi/rume"
-keywords = ["dsp", "audio", "graph"]
+keywords = ["dsp", "audio", "graph", "no_std", "no-std"]
 categories = [""]
 
 [lib]

--- a/rume_macros/src/graph.rs
+++ b/rume_macros/src/graph.rs
@@ -566,8 +566,8 @@ impl ToString for GraphDecl {
         for decl in &self.connections.decls {
             build_graph_fn.push_str(&format!(
                 "\t\t.connection(
-                    \trume::OutputPort {{ proc: {}.clone(), port: alloc::boxed::Box::new({}.clone().borrow(){}.clone()) }},
-                    \trume::InputPort {{ proc: {}.clone(), port: alloc::boxed::Box::new({}.clone().borrow(){}.clone()) }}
+                    \trume::OutputPort {{ proc: {}.clone(), port: Box::new({}.clone().borrow(){}.clone()) }},
+                    \trume::InputPort {{ proc: {}.clone(), port: Box::new({}.clone().borrow(){}.clone()) }}
                 )\n",
                 decl.tx_processor,
                 decl.tx_processor,

--- a/rume_macros/src/graph.rs
+++ b/rume_macros/src/graph.rs
@@ -566,8 +566,8 @@ impl ToString for GraphDecl {
         for decl in &self.connections.decls {
             build_graph_fn.push_str(&format!(
                 "\t\t.connection(
-                    \trume::OutputPort {{ proc: {}.clone(), port: Box::new({}.clone().borrow(){}.clone()) }},
-                    \trume::InputPort {{ proc: {}.clone(), port: Box::new({}.clone().borrow(){}.clone()) }}
+                    \trume::OutputPort {{ proc: {}.clone(), port: alloc::boxed::Box::new({}.clone().borrow(){}.clone()) }},
+                    \trume::InputPort {{ proc: {}.clone(), port: alloc::boxed::Box::new({}.clone().borrow(){}.clone()) }}
                 )\n",
                 decl.tx_processor,
                 decl.tx_processor,


### PR DESCRIPTION
For the library to be `#![no_std]` it needs the attribute and use Rust's built-in [alloc](https://doc.rust-lang.org/alloc/index.html) to abstract types that requires heap allocation. `libstd` will supply the system allocator for desktop consumer. Embedded consumers need to provide an implementation of [alloc::GlobalAlloc](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html)